### PR TITLE
Fixed indefinite cell growth

### DIFF
--- a/Source/ExpandingViewController/CollectionView/Cells/BasePageCollectionCell.swift
+++ b/Source/ExpandingViewController/CollectionView/Cells/BasePageCollectionCell.swift
@@ -182,13 +182,18 @@ extension BasePageCollectionCell {
     return shadow
   }
   
-  func configurationCell() {
-    frame.size.height += (superview?.frame.size.height)!
-    frame.origin.y -= (superview?.frame.size.height)! / 2
-    frame.origin.x -= yOffset / 2
-    frame.size.width += yOffset
-  }
-  
+	
+	func configurationCell() {
+		// Prevents indefinite growing of the cell issue
+		let i: CGFloat = self.isOpened ? 1 : -1
+		let superHeight = superview?.frame.size.height ?? 0
+		
+		frame.size.height += i * superHeight
+		frame.origin.y -= i * superHeight / 2
+		frame.origin.x -= i * yOffset / 2
+		frame.size.width += i * yOffset
+	}
+	
   
   func configureCellViewConstraintsWithSize(size: CGSize) {
     guard isOpened == false && frontContainerView.getConstraint(.Width)?.constant != size.width else { return }


### PR DESCRIPTION
On change of ‘open’ state cell size continued to grow each time rather than reduce back down to the normal size. The issue occurs in the configurationCell function and produced cell frames as follows:

> (0.0, 136.666666666667, 256.0, 335.0)
> (0.0, -167.333333333333, 256.0, 943.0)
> (0.0, -167.333333333333, 256.0, 943.0)
> (0.0, -471.333333333333, 256.0, 1551.0)
> (0.0, -471.333333333333, 256.0, 1551.0)
> (0.0, -775.333333333333, 256.0, 2159.0)
> (0.0, -775.333333333333, 256.0, 2159.0)
> (0.0, -1079.33333333333, 256.0, 2767.0)

…and so on
