### PR TITLE
fixed PageCollecitonCell's frame bug

### DIFF
--- a/Source/ExpandingViewController/CollectionView/Cells/BasePageCollectionCell.swift
+++ b/Source/ExpandingViewController/CollectionView/Cells/BasePageCollectionCell.swift
@@ -111,8 +111,8 @@ extension BasePageCollectionCell {
       heightConstant.constant = isOpen == true ? frontContainerView.bounds.size.height + yOffset : frontContainerView.bounds.size.height
     }
     
+    isOpened = isOpen
     configurationCell()
-
     
     if animated == true {
       UIView.animate(withDuration: 0.3, delay: 0, options: UIViewAnimationOptions(), animations: {
@@ -122,7 +122,6 @@ extension BasePageCollectionCell {
       self.contentView.layoutIfNeeded()
     }
    
-    isOpened = isOpen
   }
 }
 


### PR DESCRIPTION
Fixed bug, causing PageCollecitonCell's frame to shrink instead of expand. 
![artboard](https://cloud.githubusercontent.com/assets/3702281/19665881/ee9ae9d8-9a4f-11e6-8c43-09cf51c9dc91.png)

Since self.isOpened changes only after `configurationCell()` is called, in `configurationCell()` self.isOpened is incorrect. This is causing frame shrinking, instead of expanding.

This can cause unexpected behaviour, when opened cell can't respond to gestures defined in BasePageCollectionCell's subclass (e.g. buttons on the backContainerView with outlets to the subclass).
